### PR TITLE
Add more env config

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ HIGHLIGHTS_DATA_DIR="highlights_data"
 The only required environment variable is `HIGHLIGHTS_DISCORD_TOKEN`, which must be a valid Discord bot token. You can use the following environment variables to configure highlights' other behavior:
 - `HIGHLIGHTS_DATA_DIR`: Configures where highlights stores its database and backup files. Default is `./data`.
 - `HIGHLIGHTS_WEBHOOK_URL`: Should be a Discord webhook url (`https://discord.com/api/webhooks/<webhook ID>/<webhook token>`) to send error messages to. If not set, errors will only be logged to the console. (Highlights uses a webhook instead of the bot account so that it can report panic messages and not just errors.)
+- `HIGHLIGHTS_MAX_KEYWORDS`: Sets the limit of how many keywords users can have.
+- `HIGHLIGHTS_PATIENCE_SECONDS`: Sets how long to wait for activity before sending a notification.
 - `HIGHLIGHTS_LOG_FILTER`: Controls [env_logger](https://docs.rs/env_logger/0.7.1/env_logger/index.html) output; set this to `debug` to enable all console logging or `error` to only log errors. Default is `highlights=info`.
 - `HIGHLIGHTS_LOG_STYLE`: Controls [env_logger](https://docs.rs/env_logger/0.7.1/env_logger/index.html) style; set this to `never` to disable colored console output, or `always` to force colored output. See [env_logger's documentation](https://docs.rs/env_logger/0.7.1/env_logger/index.html) for more information.
 - `HIGHLIGHTS_PROMETHEUS_ADDR`: Sets the address to listen for [Prometheus](https://prometheus.io) monitoring requests.

--- a/src/commands/keywords.rs
+++ b/src/commands/keywords.rs
@@ -22,7 +22,7 @@ use super::util::{
 };
 use crate::{
 	db::{Ignore, Keyword, KeywordKind},
-	global::MAX_KEYWORDS,
+	global::max_keywords,
 	monitoring::Timer,
 	util::{error, success, MD_SYMBOL_REGEX},
 	Error,
@@ -46,9 +46,12 @@ pub async fn add(
 		let keyword_count =
 			Keyword::user_keyword_count(message.author.id).await?;
 
-		if keyword_count >= MAX_KEYWORDS {
+		if keyword_count >= max_keywords() {
 			static MSG: Lazy<String, fn() -> String> = Lazy::new(|| {
-				format!("You can't create more than {} keywords!", MAX_KEYWORDS)
+				format!(
+					"You can't create more than {} keywords!",
+					max_keywords()
+				)
 			});
 
 			return error(ctx, message, MSG.as_str()).await;

--- a/src/global.rs
+++ b/src/global.rs
@@ -8,8 +8,6 @@ use std::{env, time::Duration};
 
 pub const MAX_KEYWORDS: u32 = 100;
 
-pub const PATIENCE_DURATION: Duration = Duration::from_secs(60 * 2);
-
 pub const NOTIFICATION_RETRIES: u8 = 5;
 
 pub const EMBED_COLOR: u32 = 0xefff47;
@@ -38,12 +36,42 @@ pub fn init_mentions(bot_id: UserId) {
 
 static PRIVATE_MODE: OnceCell<bool> = OnceCell::new();
 
+const DEFAULT_PATIENCE_DURATION: Duration = Duration::from_secs(60 * 2);
+static PATIENCE_DURATION: OnceCell<Duration> = OnceCell::new();
+
 pub fn private_mode() -> bool {
 	*PRIVATE_MODE
 		.get()
 		.expect("Private mode env was not initialized")
 }
 
+pub fn patience_duration() -> Duration {
+	*PATIENCE_DURATION
+		.get()
+		.expect("Patience duration env was not initialized")
+}
+
 pub fn init_env() {
 	let _ = PRIVATE_MODE.set(env::var_os("HIGHLIGHTS_PRIVATE").is_some());
+
+	let patience_duration = match env::var("HIGHLIGHTS_PATIENCE_SECONDS") {
+		Ok(seconds) => match seconds.parse() {
+			Ok(seconds) => Some(seconds),
+			Err(e) => {
+				log::error!(
+					"HIGHLIGHTS_PATIENCE_SECONDS is an invalid number ({}): {}",
+					seconds,
+					e
+				);
+				None
+			}
+		},
+		Err(env::VarError::NotUnicode(_)) => {
+			log::error!("HIGHLIGHTS_PATIENCE_SECONDS is invalid UTF-8");
+			None
+		}
+		Err(env::VarError::NotPresent) => None,
+	}
+	.map_or(DEFAULT_PATIENCE_DURATION, Duration::from_secs);
+	let _ = PATIENCE_DURATION.set(patience_duration);
 }

--- a/src/global.rs
+++ b/src/global.rs
@@ -6,8 +6,6 @@ use serenity::model::id::UserId;
 
 use std::{env, time::Duration};
 
-pub const MAX_KEYWORDS: u32 = 100;
-
 pub const NOTIFICATION_RETRIES: u8 = 5;
 
 pub const EMBED_COLOR: u32 = 0xefff47;
@@ -36,6 +34,9 @@ pub fn init_mentions(bot_id: UserId) {
 
 static PRIVATE_MODE: OnceCell<bool> = OnceCell::new();
 
+const DEFAULT_MAX_KEYWORDS: u32 = 100;
+static MAX_KEYWORDS: OnceCell<u32> = OnceCell::new();
+
 const DEFAULT_PATIENCE_DURATION: Duration = Duration::from_secs(60 * 2);
 static PATIENCE_DURATION: OnceCell<Duration> = OnceCell::new();
 
@@ -43,6 +44,12 @@ pub fn private_mode() -> bool {
 	*PRIVATE_MODE
 		.get()
 		.expect("Private mode env was not initialized")
+}
+
+pub fn max_keywords() -> u32 {
+	*MAX_KEYWORDS
+		.get()
+		.expect("Max keywords env was not initialized")
 }
 
 pub fn patience_duration() -> Duration {
@@ -53,6 +60,27 @@ pub fn patience_duration() -> Duration {
 
 pub fn init_env() {
 	let _ = PRIVATE_MODE.set(env::var_os("HIGHLIGHTS_PRIVATE").is_some());
+
+	let max_keywords = match env::var("HIGHLIGHTS_MAX_KEYWORDS") {
+		Ok(max) => match max.parse() {
+			Ok(max) => Some(max),
+			Err(e) => {
+				log::error!(
+					"HIGHLIGHTS_MAX_KEYWORDS is an invalid number ({}): {}",
+					max,
+					e
+				);
+				None
+			}
+		},
+		Err(env::VarError::NotUnicode(_)) => {
+			log::error!("HIGHLIGHTS_MAX_KEYWORDS is invalid UTF-8");
+			None
+		}
+		Err(env::VarError::NotPresent) => None,
+	}
+	.unwrap_or(DEFAULT_MAX_KEYWORDS);
+	let _ = MAX_KEYWORDS.set(max_keywords);
 
 	let patience_duration = match env::var("HIGHLIGHTS_PATIENCE_SECONDS") {
 		Ok(seconds) => match seconds.parse() {

--- a/src/highlighting.rs
+++ b/src/highlighting.rs
@@ -13,7 +13,7 @@ use std::{convert::TryInto, ops::Range, time::Duration};
 
 use crate::{
 	db::{Ignore, Keyword, UserState, UserStateKind},
-	global::{EMBED_COLOR, NOTIFICATION_RETRIES, PATIENCE_DURATION},
+	global::{patience_duration, EMBED_COLOR, NOTIFICATION_RETRIES},
 	log_discord_error, regex,
 	util::{user_can_read_channel, MD_SYMBOL_REGEX},
 	Error,
@@ -83,7 +83,7 @@ pub async fn notify_keyword(
 		.channel_id
 		.await_reply(&ctx)
 		.author_id(user_id)
-		.timeout(PATIENCE_DURATION);
+		.timeout(patience_duration());
 
 	let reaction = message.channel_id.await_reaction(&ctx).author_id(user_id);
 


### PR DESCRIPTION
Currently the number env parsing is a bit verbose and duplicated (modified from a snippet in `reporting.rs`), but I'm not really sure where to break it out into